### PR TITLE
옵션그룹, 옵션, 상품-옵션 릴레이션 엔티티 작성

### DIFF
--- a/src/main/java/com/tmax/commerce/itemmodule/config/JpaAuditingConfig.java
+++ b/src/main/java/com/tmax/commerce/itemmodule/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.tmax.commerce.itemmodule.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/tmax/commerce/itemmodule/entity/BaseEntity.java
+++ b/src/main/java/com/tmax/commerce/itemmodule/entity/BaseEntity.java
@@ -1,0 +1,20 @@
+package com.tmax.commerce.itemmodule.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/tmax/commerce/itemmodule/entity/ItemOptionGroupRelation.java
+++ b/src/main/java/com/tmax/commerce/itemmodule/entity/ItemOptionGroupRelation.java
@@ -1,0 +1,19 @@
+package com.tmax.commerce.itemmodule.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ItemOptionGroupRelation extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "option_group_id")
+    private OptionGroup optionGroup;
+}

--- a/src/main/java/com/tmax/commerce/itemmodule/entity/Option.java
+++ b/src/main/java/com/tmax/commerce/itemmodule/entity/Option.java
@@ -15,6 +15,8 @@ public class Option extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
+    private Long originId;
+
     private String name;
 
     private Long price;
@@ -25,5 +27,8 @@ public class Option extends BaseEntity {
     @JoinColumn(name = "option_group_id")
     private OptionGroup optionGroup;
 
+    private Long versionNumber;
+
     //TODO: Status 추가
+    //TODO: Type 추가
 }

--- a/src/main/java/com/tmax/commerce/itemmodule/entity/Option.java
+++ b/src/main/java/com/tmax/commerce/itemmodule/entity/Option.java
@@ -1,0 +1,29 @@
+package com.tmax.commerce.itemmodule.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "`option`")
+public class Option extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String name;
+
+    private Long price;
+
+    private int sequence;
+
+    @ManyToOne
+    @JoinColumn(name = "option_group_id")
+    private OptionGroup optionGroup;
+
+    //TODO: Status 추가
+}

--- a/src/main/java/com/tmax/commerce/itemmodule/entity/OptionGroup.java
+++ b/src/main/java/com/tmax/commerce/itemmodule/entity/OptionGroup.java
@@ -1,0 +1,26 @@
+package com.tmax.commerce.itemmodule.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class OptionGroup extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private int min;
+
+    private int max;
+
+    private String name;
+
+    @Column
+    private Boolean required = false;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,19 @@
 spring:
   kafka:
-    bootstrap-servers: 192.168.154.131:9092
+    bootstrap-servers: ${BOOTSTRAP_SERVERS}
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DATABASE_URL}
+    password: ${DATABASE_PASSWORD}
+    username: ${DATABASE_USERNAME}
+  jpa:
+    hibernate:
+      show-sql: true
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+logging:
+  level:
+    org.hibernate.SQL: debug


### PR DESCRIPTION
## 작업내용
- application.yml 환경변수 사용하도록 설정
- 옵션그룹, 옵션, 상품-옵션 릴레이션 엔티티 작성

## 다음에 해결해야 할 문제 (Optional)
- Item과의 연관관계
- 필요 시 필드 추가

## Issue
- `option`이 MySQL 예약어이기 때문에 "\`option\`"을 엔티티 이름으로 주어 문제 해결.
